### PR TITLE
Fix internal layer thickness handling

### DIFF
--- a/fresnel_utils.py
+++ b/fresnel_utils.py
@@ -4,7 +4,12 @@ from scipy.constants import pi
 def getFresnelAIM(n, d, theta, wavelength):
     mu = np.ones(len(n))
     epsilon = np.sqrt(n**2 - (n[0] * np.sin(theta))**2)
-    beta = (2 * pi / wavelength) * np.array(d) * np.array(epsilon[1:])
+    # Thickness values are specified only for the internal layers (i.e. all
+    # layers except the first and the last).  When there are more than four
+    # layers ``epsilon[1:]`` would include the external medium and lead to a
+    # shape mismatch with ``d``.  Using ``epsilon[1:-1]`` ensures ``beta``
+    # matches the number of provided thickness values.
+    beta = (2 * pi / wavelength) * np.array(d) * np.array(epsilon[1:-1])
     q = epsilon / n**2
 
     M_tot = np.identity(2, dtype=complex)

--- a/simulador_reflectancia.py
+++ b/simulador_reflectancia.py
@@ -22,7 +22,11 @@ def executar_simulacao_reflectancia(substrato, metal, analitos, materials,
 
         for d_metal_nm in espessuras_metal_nm:
             d_metal = d_metal_nm * 1e-9
-            d = np.array([d_cr, d_metal, d_analito])
+            # The transfer-matrix routine expects thickness values only for the
+            # internal layers (here: adhesion layer and metal film).  The
+            # analyte is treated as a semi-infinite medium and therefore its
+            # thickness is omitted.
+            d = np.array([d_cr, d_metal])
             n = np.array([
                 materials[substrato],
                 materials["Cr"],


### PR DESCRIPTION
## Summary
- ensure internal layer count matches thickness array in `getFresnelAIM`
- pass only internal layer thicknesses when computing reflectance

## Testing
- `python3 -m py_compile calculo_figuras.py config_simulacao.py dados_opticos.py entrada_usuario.py figuras_de_merito.py fresnel_utils.py getFresnelWIM.py graficos_de_meritos.py main.py simulador_reflectancia.py wim.py Evanescent_ﬁeld.py`
- `python3 main.py <<'EOF'
1
PMMA
Ag
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684cbfd310fc8333b26c4d18069810fb